### PR TITLE
Added an aggregation mechanism to Lambda DD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 script: nosetests

--- a/lambda_dd_metrics.py
+++ b/lambda_dd_metrics.py
@@ -131,7 +131,7 @@ except AttributeError:
 
 class AggregatedDataDogMetrics(DataDogMetrics):
     def __init__(self, *args, **kwargs):
-        DataDogMetrics.__init__(self, *args, **kwargs)
+        super(AggregatedDataDogMetrics, self).__init__(*args, **kwargs)
         self._counts = self._make_dict_of_dicts(int)
         self._gauges = collections.defaultdict(dict)
         self._histograms = self._make_dict_of_dicts(list)
@@ -172,22 +172,22 @@ class AggregatedDataDogMetrics(DataDogMetrics):
         "Return an generator which yields each line to be printed and prints it"
         n = 0
         for metric_name, tags, count, n in self._append_count(self._consume_aggregate(self._counts)):
-            yield DataDogMetrics.incr(self, metric_name, count, tags)
+            yield super(AggregatedDataDogMetrics, self).incr(metric_name, count, tags)
         self._log_send_if_nonzero(n, "count")
 
         n = 0
         for metric_name, tags, gauge, n in self._append_count(self._consume_aggregate(self._gauges)):
-            yield DataDogMetrics.gauge(self, metric_name, gauge, tags)
+            yield super(AggregatedDataDogMetrics, self).gauge(metric_name, gauge, tags)
         self._log_send_if_nonzero(n, "gauge")
 
         n = 0
         for metric_name, tags, set_, n in self._append_count(self._consume_aggregate(self._sets, iter)):
-            yield DataDogMetrics.set(self, metric_name, set_, tags)
+            yield super(AggregatedDataDogMetrics, self).set(metric_name, set_, tags)
         self._log_send_if_nonzero(n, "set")
 
         n = 0
         for metric_name, tags, hist, n in self._append_count(self._consume_aggregate(self._histograms, iter)):
-            yield DataDogMetrics.histogram(self, metric_name, hist, tags)
+            yield super(AggregatedDataDogMetrics, self).histogram(metric_name, hist, tags)
         self._log_send_if_nonzero(n, "histogram")
 
         return

--- a/lambda_dd_metrics.py
+++ b/lambda_dd_metrics.py
@@ -130,6 +130,9 @@ except AttributeError:
 
 
 class AggregatedDataDogMetrics(DataDogMetrics):
+    ''' A wrapper for DataDogMetrics, which buffers calls to the incr, gauge, histogram and set methods,
+    and when requested sends aggregate values. The aggregation logic is specific to each metric type.
+    '''
     def __init__(self, *args, **kwargs):
         super(AggregatedDataDogMetrics, self).__init__(*args, **kwargs)
         self._counts = self._make_dict_of_dicts(int)

--- a/lambda_dd_metrics.py
+++ b/lambda_dd_metrics.py
@@ -78,7 +78,7 @@ class DataDogMetrics(object):
         '''
         Set - Send a metric that tracks the number of unique items in a set
         '''
-        # NOT SUPPORTED YET
+        raise NotImplementedError("Set isn't implemented yet")
 
     def _build_tags(self, tags=None):
         tags_type = type(tags) if tags is not None else tuple

--- a/lambda_dd_metrics.py
+++ b/lambda_dd_metrics.py
@@ -4,6 +4,7 @@ Simple interface for reporting metrics to DataDog.
 '''
 
 from __future__ import print_function
+import itertools
 from functools import wraps
 import time
 
@@ -80,7 +81,8 @@ class DataDogMetrics(object):
         # NOT SUPPORTED YET
 
     def _build_tags(self, tags=None):
-        return (tags or []) + self.default_tags
+        tags_type = type(tags) if tags is not None else tuple
+        return tags_type(itertools.chain(tags or (), self.default_tags))
 
     def _build_metric_name(self, metric_name):
         return '{0}.{1}'.format(self.service_prefix, metric_name)

--- a/lambda_dd_metrics.py
+++ b/lambda_dd_metrics.py
@@ -59,9 +59,9 @@ class DataDogMetrics(object):
         def decorator(function):
             @wraps(function)
             def wrapper(*args, **kwargs):
-                start_time = time.time()
+                start_time = self._get_timestamp()
                 ret_val = function(*args, **kwargs)
-                duration = time.time() - start_time
+                duration = self._get_timestamp() - start_time
                 self.histogram(metric_name, duration, tags)
                 return ret_val
 
@@ -80,6 +80,10 @@ class DataDogMetrics(object):
         '''
         raise NotImplementedError("Set isn't implemented yet")
 
+    @staticmethod
+    def _get_timestamp():
+        return time.time()
+
     def _build_tags(self, tags=None):
         tags_type = type(tags) if tags is not None else tuple
         return tags_type(itertools.chain(tags or (), self.default_tags))
@@ -88,7 +92,7 @@ class DataDogMetrics(object):
         return '{0}.{1}'.format(self.service_prefix, metric_name)
 
     def _print_metric(self, metric_type, metric_name, value, tags):
-        unix_epoch_timestamp = int(time.time())
+        unix_epoch_timestamp = int(self._get_timestamp())
         metric = 'MONITORING|{0}|{1}|{2}|{3}'.format(
             unix_epoch_timestamp,
             value,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lambda_dd_metrics',
-      version='1.0',
+      version='1.1',
       description='Wrapper around reporting metrics to DataDog from AWS Lambda python functions',
       url='http://github.com/500px/lambda_dd_metrics',
       author='500px Platform Team',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lambda_dd_metrics',
-      version='1.1.1',
+      version='1.1.2',
       description='Wrapper around reporting metrics to DataDog from AWS Lambda python functions',
       url='http://github.com/500px/lambda_dd_metrics',
       author='500px Platform Team',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='lambda_dd_metrics',
-      version='1.1',
+      version='1.1.1',
       description='Wrapper around reporting metrics to DataDog from AWS Lambda python functions',
       url='http://github.com/500px/lambda_dd_metrics',
       author='500px Platform Team',

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -98,3 +98,10 @@ class TestDataDogMetrics(unittest.TestCase):
         expected_call = mock.call('test_metric', float(100), None)
 
         self.assertEqual(expected_call, actual_call)
+
+    def test_set(self):
+        dd = DataDogMetrics('test')
+        with self.assertRaises(NotImplementedError):
+            dd.set('test_metric', { 1,2,3 }, [ 'tag' ])
+
+        return

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -1,4 +1,5 @@
 import unittest
+import decimal
 import sys
 
 HAS_MODERN_UNITTEST = (sys.version_info >= (3,4))
@@ -112,17 +113,17 @@ class TestDataDogMetrics(unittest.TestCase):
         mock_time.return_value = float(1234)
         dd = AggregatedDataDogMetrics('test')
         dd.incr('test_metric', 5)
-        dd.incr('test_metric', 2, [ 'tag1'])
+        dd.incr('test_metric', 2.25, [ 'tag1'])
         dd.incr('test_metric', 3),
         dd.incr('test_metric', tags =[ 'tag2', 'tag1'])
         dd.incr('test_metric')
         dd.incr('metric2', 7, [ 'tag1'])
         dd.incr('test_metric', 11, [ 'tag1', 'tag2'])
-        dd.incr('test_metric', -1, [ 'tag1'])
+        dd.incr('test_metric', decimal.Decimal("-1.25"), [ 'tag1'])
         lines = set(dd.flush())
         expected = {
             'MONITORING|1234|9|count|test.test_metric',
-            'MONITORING|1234|1|count|test.test_metric|#tag1',
+            'MONITORING|1234|1.00|count|test.test_metric|#tag1',
             'MONITORING|1234|12|count|test.test_metric|#tag1,tag2',
             'MONITORING|1234|7|count|test.metric2|#tag1',
         }

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -28,20 +28,28 @@ class TestDataDogMetrics(unittest.TestCase):
     def test_incr_with_tag(self):
         mock_time.return_value = float(1234)
         dd = DataDogMetrics('test')
-        actual = dd.incr('test_metric', tags=['tag'])
 
         expected = 'MONITORING|1234|1|count|test.test_metric|#tag'
+        for tags in (['tag'], ('tag',), {'tag'}, frozenset({'tag'})):
+            actual = dd.incr('test_metric', tags=tags)
+            self.assertEqual(expected, actual)
 
-        self.assertEqual(expected, actual)
+        return
 
     def test_incr_with_tags(self):
         mock_time.return_value = float(1234)
         dd = DataDogMetrics('test')
-        actual = dd.incr('test_metric', tags=['tag1', 'tag2'])
 
         expected = 'MONITORING|1234|1|count|test.test_metric|#tag1,tag2'
+        for tags in (['tag1', 'tag2'], ('tag1', 'tag2')):
+            actual = dd.incr('test_metric', tags=tags)
+            self.assertEqual(expected, actual)
 
-        self.assertEqual(expected, actual)
+        expected_alt_order = 'MONITORING|1234|1|count|test.test_metric|#tag2,tag1'
+        for tags in ({'tag1', 'tag2'}, frozenset({'tag1', 'tag2'})):
+            actual = dd.incr('test_metric', tags=tags)
+            self.assertLess( { actual }, { expected, expected_alt_order })
+        return
 
     def test_incr_with_stats_group(self):
         mock_time.return_value = float(1234)

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -1,13 +1,19 @@
 import unittest
+import sys
 
 from lambda_dd_metrics import DataDogMetrics
-from mock import call, MagicMock, patch
+try:
+    import mock
+except ImportError:
+    if sys.version_info < (3,4):
+        # No built-in mock library
+        raise
+    from unittest import mock
+
+mock_time = mock.MagicMock()
 
 
-mock_time = MagicMock()
-
-
-@patch('time.time', mock_time)
+@mock.patch('time.time', mock_time)
 class TestDataDogMetrics(unittest.TestCase):
 
     def test_incr(self):
@@ -76,11 +82,11 @@ class TestDataDogMetrics(unittest.TestCase):
     def test_timer(self):
         mock_time.side_effect = [float(100), float(200), float(1234)]
         dd = DataDogMetrics('test')
-        mock_histogram = dd.histogram = MagicMock(wraps=dd.histogram)
+        mock_histogram = dd.histogram = mock.MagicMock(wraps=dd.histogram)
 
         dd.timer('test_metric')(lambda x: x)('echo')
         actual_call = mock_histogram.call_args
 
-        expected_call = call('test_metric', float(100), None)
+        expected_call = mock.call('test_metric', float(100), None)
 
         self.assertEqual(expected_call, actual_call)

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -205,9 +205,9 @@ class TestDataDogMetrics(unittest.TestCase):
         dd.flush_all()
         mock_set.assert_has_calls(
             [
-                mock.call(dd, 'test_metric', 2, None),
-                mock.call(dd, 'test_metric', 5, None),
-                mock.call(dd, 'test_metric', 2, [ 'tag1']),
+                mock.call('test_metric', 2, None),
+                mock.call('test_metric', 5, None),
+                mock.call('test_metric', 2, [ 'tag1']),
             ],
             any_order = True
         )

--- a/test_lambda_dd_metrics.py
+++ b/test_lambda_dd_metrics.py
@@ -13,7 +13,7 @@ except ImportError:
 mock_time = mock.MagicMock()
 
 
-@mock.patch('time.time', mock_time)
+@mock.patch('lambda_dd_metrics.DataDogMetrics._get_timestamp', mock_time)
 class TestDataDogMetrics(unittest.TestCase):
 
     def test_incr(self):


### PR DESCRIPTION
I've added a class which inherits DataDogMetrics and aggregates the metrics internally until is it requested to flush them. Then it uses the services of DataDogMetrics to write the aggregate metrics. I've also made large improvements to the regression tests and added more uniform handling of fractional values in counters.